### PR TITLE
Update beans.xml

### DIFF
--- a/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/beans.xml
+++ b/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/beans.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
-       bean-discovery-mode="all">
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_1.xsd"
+       bean-discovery-mode="annotated">
 </beans>


### PR DESCRIPTION
- Jakarta EE 11 uses beans version 4.1, the xsd files are in NetBeans already
- Beans 4.1 default and recommended `bean-discovery-mode` is `annotated`

I will be testing Jakarta EE 11 support now that GlassFish 8 is approaching GA. 

Happy new year Josh!